### PR TITLE
Add boot image + QEMU integration test to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,14 @@ jobs:
 
       - name: Boot test (QEMU)
         run: |
-          # Boot with serial output, kill after 5 seconds.
-          # readonly=on because the Nix store is read-only (and we
-          # don't need disk writes -- it's a boot sector).
+          # Copy boot image out of the Nix store and make it writable.
+          # QEMU requires write access to disk images even if we don't
+          # write to them. The Nix store is read-only, and cp preserves
+          # those permissions, so we chmod after copying.
+          install -m 644 result /tmp/boot.img
+          # Boot with serial output, kill after 5 seconds
           timeout 5 qemu-system-i386 \
-            -drive format=raw,file=result,readonly=on \
+            -drive format=raw,file=/tmp/boot.img \
             -serial stdio \
             -display none 2>&1 | tee /tmp/boot_output.txt || true
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,17 @@ jobs:
       #    a virtual x86 CPU and verify it prints the expected message
       #    over the serial port. If the assembler encodes a single
       #    instruction wrong, this test catches it.
+      #
+      #    We install QEMU via apt rather than Nix here -- pulling QEMU
+      #    through Nix would download hundreds of dependencies. The boot
+      #    image is already built by Nix; we just need something to run it.
+      - name: Install QEMU
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq qemu-system-x86
+
       - name: Boot test (QEMU)
         run: |
           # Boot with serial output, kill after 5 seconds
-          timeout 5 nix develop --command qemu-system-i386 \
+          timeout 5 qemu-system-i386 \
             -drive format=raw,file=result \
             -serial stdio \
             -display none 2>&1 | tee /tmp/boot_output.txt || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,11 +102,11 @@ jobs:
 
       - name: Boot test (QEMU)
         run: |
-          # Copy boot image out of the Nix store (which is read-only)
-          cp result /tmp/boot.img
-          # Boot with serial output, kill after 5 seconds
+          # Boot with serial output, kill after 5 seconds.
+          # readonly=on because the Nix store is read-only (and we
+          # don't need disk writes -- it's a boot sector).
           timeout 5 qemu-system-i386 \
-            -drive format=raw,file=/tmp/boot.img \
+            -drive format=raw,file=result,readonly=on \
             -serial stdio \
             -display none 2>&1 | tee /tmp/boot_output.txt || true
           echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,55 @@ jobs:
       - name: Smoke test
         run: nix run 2>&1 | grep -q "supreme-computing-machine"
 
-      # 6. Show what we built (informational).
+      # 6. Build the boot sector image.
+      #    The OCaml assembler produces a 512-byte bootable disk image.
+      #    We verify: it exists, it's exactly 512 bytes, and it ends
+      #    with the 0x55AA boot signature.
+      - name: Build boot image
+        run: |
+          nix build .#boot-image
+          echo "Boot image built:"
+          ls -la result
+          SIZE=$(wc -c < result)
+          echo "Size: $SIZE bytes"
+          if [ "$SIZE" -ne 512 ]; then
+            echo "FAIL: boot image must be exactly 512 bytes"
+            exit 1
+          fi
+          # Check for 0x55AA boot signature at bytes 510-511
+          MAGIC=$(xxd -s 510 -l 2 -p result)
+          echo "Boot signature: $MAGIC"
+          if [ "$MAGIC" != "55aa" ]; then
+            echo "FAIL: missing boot signature 0x55AA"
+            exit 1
+          fi
+          echo "Boot image OK"
+
+      # 7. Integration test: boot the image in QEMU and check serial output.
+      #    This is the real deal -- we actually run the bootloader on
+      #    a virtual x86 CPU and verify it prints the expected message
+      #    over the serial port. If the assembler encodes a single
+      #    instruction wrong, this test catches it.
+      - name: Boot test (QEMU)
+        run: |
+          # Boot with serial output, kill after 5 seconds
+          timeout 5 nix develop --command qemu-system-i386 \
+            -drive format=raw,file=result \
+            -serial stdio \
+            -display none 2>&1 | tee /tmp/boot_output.txt || true
+          echo ""
+          echo "=== Serial output ==="
+          cat /tmp/boot_output.txt
+          echo ""
+          # Verify the expected message appeared
+          if grep -q "Hello from OCaml bootloader!" /tmp/boot_output.txt; then
+            echo "PASS: bootloader message detected"
+          else
+            echo "FAIL: expected 'Hello from OCaml bootloader!' in serial output"
+            exit 1
+          fi
+
+      # 8. Show what we built (informational).
       - name: Show build output
         run: |
           nix build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,9 +102,11 @@ jobs:
 
       - name: Boot test (QEMU)
         run: |
+          # Copy boot image out of the Nix store (which is read-only)
+          cp result /tmp/boot.img
           # Boot with serial output, kill after 5 seconds
           timeout 5 qemu-system-i386 \
-            -drive format=raw,file=result \
+            -drive format=raw,file=/tmp/boot.img \
             -serial stdio \
             -display none 2>&1 | tee /tmp/boot_output.txt || true
           echo ""


### PR DESCRIPTION
## Summary
- CI now builds the boot sector image and verifies it's exactly 512 bytes with the `0x55AA` boot signature
- Actually boots the image in QEMU with serial output and checks for `Hello from OCaml bootloader!`
- If the assembler encodes a single instruction wrong, CI catches it

## What this tests
1. **Boot image structure** — 512 bytes, valid boot signature
2. **x86 instruction encoding** — every opcode, ModRM byte, and label offset must be correct or the CPU won't print the message
3. **Serial port I/O** — UART init, LSR polling, and data write all have to work
4. **Two-pass assembler** — label resolution must produce correct addresses

## Test plan
- [ ] CI passes on this PR (build + test + boot image + QEMU integration)
- [ ] Existing tests still pass (DNS parser + x86 assembler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)