### PR TITLE
Add keyboard input for interactive bootloader shell

### DIFF
--- a/bin/boot_sector.ml
+++ b/bin/boot_sector.ml
@@ -17,9 +17,9 @@ open X86_asm.Types
    What it does:
    1. Set up segment registers (required for memory access)
    2. Initialize COM1 serial port (0x3F8) for output
-   3. Point SI to our message string
-   4. Print each character to BOTH VGA screen and serial port
-   5. Halt the CPU forever
+   3. Print a welcome message
+   4. Enter an interactive loop: read keystrokes, echo them
+   5. Handle Enter (new line + prompt) and 'q' (halt)
 
    With serial output, the bootloader works in headless mode too:
      qemu-system-i386 -drive format=raw,file=boot.img -nographic
@@ -86,14 +86,53 @@ let boot_program = [
   Mov_r8_imm (AL, 0x0B);            (* DTR + RTS + OUT2 (enables IRQs) *)
   Out_dx_al;
 
-  (* ---- Load message address and print ---- *)
-  Mov_r16_imm (SI, Label "message");  (* SI -> our string *)
-  Call "print_string";                 (* print it! *)
+  (* ---- Print welcome message ---- *)
+  Mov_r16_imm (SI, Label "welcome");
+  Call "print_string";
 
-  (* ---- Halt: infinite loop ----
-     HLT stops the CPU until an interrupt. The JMP catches
-     any spurious interrupts and re-halts. *)
+  (* ---- Print prompt and enter interactive loop ----
+     This is where it gets fun: we read keystrokes from the
+     keyboard and echo them back. It's the world's simplest REPL,
+     running with zero OS underneath.
+
+     BIOS INT 0x16, AH=0x00: wait for keypress.
+       Returns: AL = ASCII character, AH = scan code.
+     We handle three cases:
+       Enter (0x0D) -> print newline + new prompt
+       'q'          -> halt the machine
+       anything else -> echo it back *)
+  Label_def "prompt";
+  Mov_r16_imm (SI, Label "prompt_str");
+  Call "print_string";
+
+  Label_def "read_key";
+  Mov_r8_imm (AH, 0x00);       (* BIOS: wait for keypress *)
+  Int 0x16;                     (* AL = ASCII char *)
+
+  (* Check for Enter key (carriage return = 0x0D) *)
+  Cmp_al_imm 0x0D;
+  Jz "handle_enter";
+
+  (* Check for 'q' to quit *)
+  Cmp_al_imm 0x71;             (* 'q' = 0x71 *)
+  Jz "halt";
+
+  (* Echo the character *)
+  Call "putchar";
+  Jmp "read_key";
+
+  (* Handle Enter: print CR+LF then new prompt *)
+  Label_def "handle_enter";
+  Mov_r8_imm (AL, 0x0D);       (* carriage return *)
+  Call "putchar";
+  Mov_r8_imm (AL, 0x0A);       (* line feed *)
+  Call "putchar";
+  Jmp "prompt";                 (* show new prompt *)
+
+  (* ---- Halt ---- *)
   Label_def "halt";
+  Mov_r16_imm (SI, Label "bye_str");
+  Call "print_string";
   Cli;
   Hlt;
   Jmp "halt";
@@ -147,9 +186,17 @@ let boot_program = [
   Pop_r16 DX;                   (* restore DX *)
   Ret;
 
-  (* ---- The message ---- *)
-  Label_def "message";
-  Dstring "Hello from OCaml bootloader!";
+  (* ---- Data ----
+     \r\n = CR+LF, the standard line ending for serial terminals.
+     Dstring adds a null terminator so print_string knows where to stop. *)
+  Label_def "welcome";
+  Dstring "Hello from OCaml bootloader!\r\nType anything. Press 'q' to halt.\r\n";
+
+  Label_def "prompt_str";
+  Dstring "> ";
+
+  Label_def "bye_str";
+  Dstring "\r\nHalted.";
 ]
 
 (* ---- Assemble and write the boot image ---- *)

--- a/bootloader/encoder.ml
+++ b/bootloader/encoder.ml
@@ -49,9 +49,11 @@ let instruction_size (instr : Types.instruction) =
   | Xor_r16_r16 _ -> 2       (* opcode + ModRM *)
   | Test_r8_r8 _ -> 2        (* opcode + ModRM *)
   | Test_al_imm _ -> 2       (* 0xA8, imm8 *)
+  | Cmp_al_imm _ -> 2        (* 0x3C, imm8 *)
   | Mov_r8_imm _ -> 2        (* opcode+reg, imm8 *)
   | Int _ -> 2               (* 0xCD, imm8 *)
   | Jz _ -> 2                (* 0x74, rel8 *)
+  | Jnz _ -> 2               (* 0x75, rel8 *)
   | Jmp _ -> 2               (* 0xEB, rel8 *)
   (* Three-byte instructions *)
   | Mov_r16_imm _ -> 3       (* opcode+reg, imm16 LE *)
@@ -126,6 +128,15 @@ let encode_instruction (emit : Emitter.t) ~labels ~offset
     Emitter.emit_uint8 emit imm;
     Ok ()
 
+  (* -- CMP AL, imm8 --
+     Opcode 0x3C = special short form for comparing AL.
+     Subtracts imm from AL, sets flags, discards result.
+     Use JZ/JNZ after to branch on equal/not-equal. *)
+  | Cmp_al_imm imm ->
+    Emitter.emit_uint8 emit 0x3C;
+    Emitter.emit_uint8 emit imm;
+    Ok ()
+
   (* -- MOV r16, imm16 --
      Opcode = 0xB8 + register code
      Followed by 16-bit little-endian immediate *)
@@ -176,6 +187,21 @@ let encode_instruction (emit : Emitter.t) ~labels ~offset
          Error (Relative_jump_out_of_range (label_name, rel))
        else begin
          Emitter.emit_uint8 emit 0x74;
+         Emitter.emit_int8 emit rel;
+         Ok ()
+       end)
+
+  (* -- JNZ rel8 (jump if NOT zero/equal) --
+     Opcode 0x75, the complement of JZ (0x74). *)
+  | Jnz label_name ->
+    (match resolve_label labels label_name with
+     | Error e -> Error e
+     | Ok target ->
+       let rel = target - (offset + 2) in
+       if rel < -128 || rel > 127 then
+         Error (Relative_jump_out_of_range (label_name, rel))
+       else begin
+         Emitter.emit_uint8 emit 0x75;
          Emitter.emit_int8 emit rel;
          Ok ()
        end)

--- a/bootloader/types.ml
+++ b/bootloader/types.ml
@@ -76,6 +76,7 @@ type instruction =
   | Xor_r16_r16 of reg16 * reg16       (* 0x31 + ModRM: XOR dst, src *)
   | Test_r8_r8 of reg8 * reg8          (* 0x84 + ModRM: AND without storing *)
   | Test_al_imm of int                  (* 0xA8 imm8: AND AL with immediate *)
+  | Cmp_al_imm of int                   (* 0x3C imm8: compare AL with immediate *)
 
   (* -- Register-immediate operations -- *)
   | Mov_r16_imm of reg16 * imm16       (* 0xB8+reg, LE16: load 16-bit value *)
@@ -87,6 +88,7 @@ type instruction =
 
   (* -- Control flow (all reference labels) -- *)
   | Jz of string                        (* 0x74 rel8: jump if zero flag set *)
+  | Jnz of string                       (* 0x75 rel8: jump if NOT zero/equal *)
   | Jmp of string                       (* 0xEB rel8: unconditional short jump *)
   | Call of string                      (* 0xE8 rel16: near call *)
 
@@ -143,6 +145,7 @@ let string_of_instruction = function
   | Test_r8_r8 (a, b) ->
     Printf.sprintf "test %s, %s" (string_of_reg8 a) (string_of_reg8 b)
   | Test_al_imm v -> Printf.sprintf "test al, 0x%02X" v
+  | Cmp_al_imm v -> Printf.sprintf "cmp al, 0x%02X" v
   | Mov_r16_imm (r, v) ->
     Printf.sprintf "mov %s, %s" (string_of_reg16 r) (string_of_imm16 v)
   | Mov_r8_imm (r, v) ->
@@ -151,6 +154,7 @@ let string_of_instruction = function
     Printf.sprintf "mov %s, %s" (string_of_seg_reg seg) (string_of_reg16 r)
   | Int n -> Printf.sprintf "int 0x%02X" n
   | Jz lbl -> Printf.sprintf "jz %s" lbl
+  | Jnz lbl -> Printf.sprintf "jnz %s" lbl
   | Jmp lbl -> Printf.sprintf "jmp %s" lbl
   | Call lbl -> Printf.sprintf "call %s" lbl
   | Org n -> Printf.sprintf "org 0x%04X" n

--- a/bootloader/types.mli
+++ b/bootloader/types.mli
@@ -37,11 +37,13 @@ type instruction =
   | Xor_r16_r16 of reg16 * reg16
   | Test_r8_r8 of reg8 * reg8
   | Test_al_imm of int
+  | Cmp_al_imm of int
   | Mov_r16_imm of reg16 * imm16
   | Mov_r8_imm of reg8 * int
   | Mov_seg_r16 of seg_reg * reg16
   | Int of int
   | Jz of string
+  | Jnz of string
   | Jmp of string
   | Call of string
   | Org of int

--- a/test/test_x86.ml
+++ b/test/test_x86.ml
@@ -136,6 +136,19 @@ let test_test_al_imm () =
   (* TEST AL, 0x20: opcode 0xA8, imm8 0x20 *)
   check_bytes "test al, 0x20" [0xA8; 0x20] [Types.Test_al_imm 0x20]
 
+let test_cmp_al_imm () =
+  (* CMP AL, 0x0D: opcode 0x3C, imm8 0x0D *)
+  check_bytes "cmp al, 0x0D" [0x3C; 0x0D] [Types.Cmp_al_imm 0x0D]
+
+let test_jnz_forward () =
+  (* JNZ skip:
+     offset 0: jnz skip  (2 bytes: 0x75, 0x01)
+     offset 2: hlt       (1 byte)
+     offset 3: skip:
+     rel = 3 - (0 + 2) = 1 *)
+  check_bytes "jnz forward" [0x75; 0x01; 0xF4]
+    [Types.Jnz "skip"; Types.Hlt; Types.Label_def "skip"]
+
 (* ================================================================
    Interrupts
    ================================================================ *)
@@ -277,6 +290,8 @@ let () =
       Alcotest.test_case "out dx, al" `Quick test_out_dx_al;
       Alcotest.test_case "in al, dx" `Quick test_in_al_dx;
       Alcotest.test_case "test al, imm" `Quick test_test_al_imm;
+      Alcotest.test_case "cmp al, imm" `Quick test_cmp_al_imm;
+      Alcotest.test_case "jnz forward" `Quick test_jnz_forward;
     ];
     "register-register", [
       Alcotest.test_case "xor ax, ax" `Quick test_xor_ax_ax;


### PR DESCRIPTION
## Summary
- New assembler instructions: `cmp al, imm` (0x3C) and `jnz` (0x75) for comparing keystrokes
- Bootloader is now interactive: reads keystrokes via BIOS INT 0x16, echoes to VGA + serial
- Enter key prints a new prompt, 'q' halts the machine
- 219 bytes of code (still well within the 512-byte boot sector limit)

## What it does
```
Hello from OCaml bootloader!
Type anything. Press 'q' to halt.
> hi
>
Halted.
```

A tiny REPL running on bare metal — zero OS, just BIOS and our OCaml-assembled x86.

## Test plan
- [ ] CI passes (34 x86 tests + 11 DNS tests + boot image + QEMU integration)
- [ ] Welcome message appears over serial
- [ ] Keystrokes echo back
- [ ] Enter gives new prompt, 'q' halts

🤖 Generated with [Claude Code](https://claude.com/claude-code)