### PR TITLE
Add command shell with help, halt, and reboot

### DIFF
--- a/bin/boot_sector.ml
+++ b/bin/boot_sector.ml
@@ -90,52 +90,102 @@ let boot_program = [
   Mov_r16_imm (SI, Label "welcome");
   Call "print_string";
 
-  (* ---- Print prompt and enter interactive loop ----
-     This is where it gets fun: we read keystrokes from the
-     keyboard and echo them back. It's the world's simplest REPL,
-     running with zero OS underneath.
+  (* ---- Interactive command shell ----
+     We buffer keystrokes at 0x7E00 (512 bytes above our boot sector,
+     safely in unused memory). On Enter, we compare the buffer against
+     known commands.
 
-     BIOS INT 0x16, AH=0x00: wait for keypress.
-       Returns: AL = ASCII character, AH = scan code.
-     We handle three cases:
-       Enter (0x0D) -> print newline + new prompt
-       'q'          -> halt the machine
-       anything else -> echo it back *)
+     MEMORY MAP:
+       0x7C00-0x7DFF  Our boot sector (512 bytes)
+       0x7E00-0x7EFF  Input buffer (256 bytes, more than enough)
+
+     STOSB stores AL at [ES:DI] and increments DI -- the inverse
+     of LODSB. We use it to build the input buffer character by
+     character as the user types. *)
+
   Label_def "prompt";
   Mov_r16_imm (SI, Label "prompt_str");
   Call "print_string";
+  Mov_r16_imm (DI, Imm16 0x7E00);  (* reset buffer pointer *)
 
   Label_def "read_key";
   Mov_r8_imm (AH, 0x00);       (* BIOS: wait for keypress *)
   Int 0x16;                     (* AL = ASCII char *)
 
-  (* Check for Enter key (carriage return = 0x0D) *)
+  (* Enter key -> process the command *)
   Cmp_al_imm 0x0D;
-  Jz "handle_enter";
+  Jz "run_command";
 
-  (* Check for 'q' to quit *)
-  Cmp_al_imm 0x71;             (* 'q' = 0x71 *)
-  Jz "halt";
-
-  (* Echo the character *)
+  (* Buffer the character and echo it *)
+  Stosb;                        (* [ES:DI] = AL, DI++ *)
   Call "putchar";
   Jmp "read_key";
 
-  (* Handle Enter: print CR+LF then new prompt *)
-  Label_def "handle_enter";
-  Mov_r8_imm (AL, 0x0D);       (* carriage return *)
-  Call "putchar";
-  Mov_r8_imm (AL, 0x0A);       (* line feed *)
-  Call "putchar";
-  Jmp "prompt";                 (* show new prompt *)
+  (* ---- Command dispatcher ----
+     On Enter: null-terminate the buffer, print newline, then
+     compare the input against known commands using LODSB.
 
-  (* ---- Halt ---- *)
-  Label_def "halt";
-  Mov_r16_imm (SI, Label "bye_str");
+     We match on the first two characters since all commands
+     are unique by their first two letters:
+       "he..." -> help
+       "ha..." -> halt
+       "re..." -> reboot *)
+  Label_def "run_command";
+  Mov_r8_imm (AL, 0x00);       (* null-terminate the buffer *)
+  Stosb;
+  (* Print newline *)
+  Mov_r8_imm (AL, 0x0D);
+  Call "putchar";
+  Mov_r8_imm (AL, 0x0A);
+  Call "putchar";
+
+  (* Read first character of input *)
+  Mov_r16_imm (SI, Imm16 0x7E00);
+  Lodsb;
+  (* Empty line? just reprompt *)
+  Cmp_al_imm 0x00;
+  Jz "prompt";
+  (* Commands starting with 'h' *)
+  Cmp_al_imm 0x68;             (* 'h' *)
+  Jz "check_h";
+  (* Commands starting with 'r' *)
+  Cmp_al_imm 0x72;             (* 'r' *)
+  Jz "do_reboot";
+  Jmp "unknown_cmd";
+
+  (* Disambiguate: "help" vs "halt" by second character *)
+  Label_def "check_h";
+  Lodsb;
+  Cmp_al_imm 0x65;             (* 'e' -> help *)
+  Jz "do_help";
+  Cmp_al_imm 0x61;             (* 'a' -> halt *)
+  Jz "do_halt";
+  Jmp "unknown_cmd";
+
+  (* ---- Command handlers ---- *)
+  Label_def "do_help";
+  Mov_r16_imm (SI, Label "help_text");
+  Call "print_string";
+  Jmp "prompt";
+
+  Label_def "do_halt";
+  Mov_r16_imm (SI, Label "halt_text");
   Call "print_string";
   Cli;
   Hlt;
-  Jmp "halt";
+  Jmp "do_halt";
+
+  (* INT 0x19: the BIOS bootstrap interrupt.
+     This is what the BIOS calls to boot the machine.
+     Calling it again reboots -- loads sector 0 and jumps to 0x7C00.
+     Our bootloader runs again from scratch! *)
+  Label_def "do_reboot";
+  Int 0x19;
+
+  Label_def "unknown_cmd";
+  Mov_r16_imm (SI, Label "unknown_text");
+  Call "print_string";
+  Jmp "prompt";
 
   (* ---- print_string subroutine ----
      Prints null-terminated string at DS:SI to BOTH outputs:
@@ -186,17 +236,21 @@ let boot_program = [
   Pop_r16 DX;                   (* restore DX *)
   Ret;
 
-  (* ---- Data ----
-     \r\n = CR+LF, the standard line ending for serial terminals.
-     Dstring adds a null terminator so print_string knows where to stop. *)
+  (* ---- Data ---- *)
   Label_def "welcome";
-  Dstring "Hello from OCaml bootloader!\r\nType anything. Press 'q' to halt.\r\n";
+  Dstring "Hello from OCaml bootloader!\r\nType 'help' for commands.\r\n";
 
   Label_def "prompt_str";
   Dstring "> ";
 
-  Label_def "bye_str";
-  Dstring "\r\nHalted.";
+  Label_def "help_text";
+  Dstring "Commands: help halt reboot";
+
+  Label_def "halt_text";
+  Dstring "Halted.";
+
+  Label_def "unknown_text";
+  Dstring "Unknown command. Try 'help'.";
 ]
 
 (* ---- Assemble and write the boot image ---- *)

--- a/bootloader/encoder.ml
+++ b/bootloader/encoder.ml
@@ -40,7 +40,7 @@ let modrm_reg ~reg ~rm =
 let instruction_size (instr : Types.instruction) =
   match instr with
   (* Single-byte instructions *)
-  | Cli | Sti | Hlt | Ret | Lodsb -> 1
+  | Cli | Sti | Hlt | Ret | Lodsb | Stosb -> 1
   | Push_r16 _ -> 1           (* 0x50+reg *)
   | Pop_r16 _ -> 1            (* 0x58+reg *)
   | Out_dx_al -> 1            (* 0xEE *)
@@ -84,6 +84,11 @@ let encode_instruction (emit : Emitter.t) ~labels ~offset
   | Hlt -> Emitter.emit_uint8 emit 0xF4; Ok ()
   | Ret -> Emitter.emit_uint8 emit 0xC3; Ok ()
   | Lodsb -> Emitter.emit_uint8 emit 0xAC; Ok ()
+
+  (* -- STOSB: store AL to [ES:DI], increment DI --
+     The inverse of LODSB. Used to build buffers in memory.
+     Here we use it to save typed characters into a line buffer. *)
+  | Stosb -> Emitter.emit_uint8 emit 0xAA; Ok ()
 
   (* -- PUSH r16 / POP r16 --
      The stack is fundamental to subroutine calls.

--- a/bootloader/types.ml
+++ b/bootloader/types.ml
@@ -60,6 +60,7 @@ type instruction =
   | Hlt                                 (* 0xF4: halt until interrupt *)
   | Ret                                 (* 0xC3: return from call *)
   | Lodsb                               (* 0xAC: load byte [DS:SI] -> AL, inc SI *)
+  | Stosb                               (* 0xAA: store AL -> [ES:DI], inc DI *)
 
   (* -- Stack operations -- *)
   | Push_r16 of reg16                   (* 0x50+reg: push register onto stack *)
@@ -136,6 +137,7 @@ let string_of_instruction = function
   | Hlt -> "hlt"
   | Ret -> "ret"
   | Lodsb -> "lodsb"
+  | Stosb -> "stosb"
   | Push_r16 r -> Printf.sprintf "push %s" (string_of_reg16 r)
   | Pop_r16 r -> Printf.sprintf "pop %s" (string_of_reg16 r)
   | Out_dx_al -> "out dx, al"

--- a/bootloader/types.mli
+++ b/bootloader/types.mli
@@ -30,6 +30,7 @@ type instruction =
   | Hlt
   | Ret
   | Lodsb
+  | Stosb
   | Push_r16 of reg16
   | Pop_r16 of reg16
   | Out_dx_al

--- a/test/test_x86.ml
+++ b/test/test_x86.ml
@@ -43,6 +43,9 @@ let test_hlt () =
 let test_ret () =
   check_bytes "ret = 0xC3" [0xC3] [Types.Ret]
 
+let test_stosb () =
+  check_bytes "stosb = 0xAA" [0xAA] [Types.Stosb]
+
 let test_lodsb () =
   check_bytes "lodsb = 0xAC" [0xAC] [Types.Lodsb]
 
@@ -279,6 +282,7 @@ let () =
       Alcotest.test_case "hlt" `Quick test_hlt;
       Alcotest.test_case "ret" `Quick test_ret;
       Alcotest.test_case "lodsb" `Quick test_lodsb;
+      Alcotest.test_case "stosb" `Quick test_stosb;
     ];
     "stack", [
       Alcotest.test_case "push ax" `Quick test_push_ax;


### PR DESCRIPTION
## Summary
- New assembler instruction: `stosb` (0xAA) — store AL to memory at [ES:DI]
- Bootloader buffers keystrokes in memory at 0x7E00, processes on Enter
- Three commands: `help`, `halt`, `reboot` (INT 0x19 — BIOS bootstrap)
- 313 bytes of code, 197 bytes free in the 512-byte boot sector

## What it looks like
```
Hello from OCaml bootloader!
Type 'help' for commands.
> help
Commands: help halt reboot
> halt
Halted.
```

## New concepts
- **STOSB**: the inverse of LODSB — writes AL to memory, building a line buffer
- **Memory layout**: boot sector at 0x7C00, input buffer at 0x7E00
- **INT 0x19**: BIOS bootstrap interrupt — calling it reboots the machine
- **Command dispatch**: prefix-match on first two characters

## Test plan
- [ ] CI passes (35 x86 tests + boot image + QEMU integration)
- [ ] `help` prints command list
- [ ] `halt` stops the CPU
- [ ] `reboot` restarts (INT 0x19)
- [ ] Unknown commands print error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)